### PR TITLE
Add CLI tool for Demark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Test Commands
+
+### Package Building
+```bash
+# Build the library
+swift build
+
+# Build the CLI tool
+swift build --product demark
+
+# Build for release
+swift build -c release --product demark
+
+# Build for specific platform
+swift build -Xswiftc -target -Xswiftc x86_64-apple-macos14.0
+```
+
+### Testing
+```bash
+# Run all tests (uses both XCTest and swift-testing)
+swift test
+
+# Run specific test suite
+swift test --filter DemarkIntegrationTests
+
+# Run with verbose output
+swift test --parallel --verbose
+```
+
+### Running the Example App
+```bash
+# Quick way - use the helper script
+./run-example.sh
+
+# Manual way
+cd Example
+swift run DemarkExample
+
+# Generate Xcode project for example (requires XcodeGen)
+cd Example
+./generate-xcodeproj.sh
+```
+
+### Code Quality
+```bash
+# Run all linting and formatting checks
+./scripts/lint.sh
+
+# Run SwiftFormat (check only)
+./scripts/swiftformat.sh --check
+
+# Run SwiftFormat (auto-fix)
+./scripts/swiftformat.sh
+
+# Run SwiftLint
+./scripts/swiftlint.sh
+
+# Run SwiftLint with auto-fix
+./scripts/swiftlint.sh --fix
+```
+
+## Architecture Overview
+
+### Main Components
+
+1. **Demark Core** (`Sources/Demark/`)
+   - `Demark.swift`: Main API entry point, @MainActor isolated
+   - `DemarkTypes.swift`: Public types and configuration options
+   - `TurndownRuntime.swift`: WKWebView-based Turndown.js implementation
+   - `HTMLToMdRuntime.swift`: JavaScriptCore-based html-to-md implementation
+   - `BundleResourceHelper.swift`: Resource loading utilities
+
+2. **Dual Engine Architecture**
+   - **Turndown.js**: Full DOM parsing via WKWebView, most accurate but slower (~100ms first, ~10-50ms subsequent)
+   - **html-to-md**: Lightweight JavaScriptCore engine, faster (~5-10ms) but less accurate
+
+3. **CLI Tool** (`Sources/DemarkCLI/`)
+   - Uses Swift Argument Parser
+   - Supports both conversion engines
+   - Handles file input/output and stdin/stdout
+
+### Key Design Decisions
+
+1. **Main Actor Requirement**: All public APIs are @MainActor due to WKWebView constraints
+2. **Swift 6 Concurrency**: Full strict concurrency checking enabled
+3. **Resource Bundling**: JavaScript libraries bundled as resources, loaded dynamically
+4. **Protocol-Based Design**: Clean separation between different runtime implementations
+5. **Error Handling**: Comprehensive error types with localized descriptions
+
+### Testing Strategy
+
+- **Migration in Progress**: Moving from XCTest to swift-testing
+- **Integration Tests**: Test actual HTML to Markdown conversions
+- **Service Tests**: Test individual components and edge cases
+- **Platform Coverage**: Tests run on all supported platforms
+
+### Important Notes
+
+- WKWebView requires main thread execution - all conversions must happen on @MainActor
+- The package has zero external dependencies (only uses WebKit framework)
+- JavaScript libraries are minified and bundled in Resources/
+- Swift 6 language mode is enforced throughout the project

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "03e1430559b98d5a9ec473702a264529ca29139d398508f4e9b735c1cf6a11b5",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
+        "version" : "1.5.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,13 @@ let package = Package(
             name: "Demark",
             targets: ["Demark"]
         ),
+        .executable(
+            name: "demark",
+            targets: ["DemarkCLI"]
+        ),
     ],
     dependencies: [
-        // No external dependencies - uses only WebKit and Foundation
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [
         .target(
@@ -27,6 +31,16 @@ let package = Package(
             dependencies: [],
             resources: [
                 .process("Resources")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
+        .executableTarget(
+            name: "DemarkCLI",
+            dependencies: [
+                "Demark",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")

--- a/README.md
+++ b/README.md
@@ -163,6 +163,52 @@ Then add it to your target:
 )
 ```
 
+### Command-Line Tool
+
+Demark also includes a command-line tool for converting HTML files to Markdown:
+
+```bash
+# Build the CLI tool
+swift build -c release --product demark
+
+# Install to /usr/local/bin (optional)
+cp .build/release/demark /usr/local/bin/
+
+# Or run directly from the build directory
+.build/release/demark --help
+```
+
+#### CLI Usage
+
+```bash
+# Convert a file
+demark input.html -o output.md
+
+# Use stdin/stdout
+echo "<h1>Hello</h1>" | demark -
+
+# Use the fast html-to-md engine
+demark input.html --engine html-to-md
+
+# Customize output format
+demark input.html \
+  --heading-style setext \
+  --bullet-list-marker "*" \
+  --code-block-style indented
+
+# Verbose mode
+demark input.html -v
+```
+
+#### CLI Options
+
+- `-o, --output`: Output file path (default: stdout)
+- `-e, --engine`: Conversion engine (`turndown` or `html-to-md`)
+- `-h, --heading-style`: Heading style (`atx` or `setext`)
+- `-b, --bullet-list-marker`: Bullet list marker (`-`, `*`, or `+`)
+- `-c, --code-block-style`: Code block style (`fenced` or `indented`)
+- `-v, --verbose`: Enable verbose output
+
 ## Usage
 
 ### Basic Conversion

--- a/Sources/DemarkCLI/DemarkCLI.swift
+++ b/Sources/DemarkCLI/DemarkCLI.swift
@@ -1,0 +1,136 @@
+import ArgumentParser
+import Demark
+import Foundation
+
+@main
+struct DemarkCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "demark",
+        abstract: "Convert HTML to Markdown",
+        discussion: """
+        A command-line tool for converting HTML content to Markdown format.
+        
+        Supports two conversion engines:
+        - turndown (default): Full DOM parsing with better fidelity
+        - html-to-md: Faster lightweight conversion
+        """,
+        version: "1.0.0"
+    )
+    
+    @Argument(help: "HTML input file path or '-' for stdin")
+    var input: String
+    
+    @Option(name: .shortAndLong, help: "Output file path (default: stdout)")
+    var output: String?
+    
+    @Option(name: .shortAndLong, help: "Conversion engine: turndown (default) or html-to-md")
+    var engine: EngineType = .turndown
+    
+    @Option(name: .shortAndLong, help: "Heading style: setext or atx (default)")
+    var headingStyle: HeadingStyleType = .atx
+    
+    @Option(name: .shortAndLong, help: "Bullet list marker: -, *, or + (default: -)")
+    var bulletListMarker: String = "-"
+    
+    @Option(name: .shortAndLong, help: "Code block style: indented or fenced (default)")
+    var codeBlockStyle: CodeBlockStyleType = .fenced
+    
+    @Flag(name: .shortAndLong, help: "Enable verbose output")
+    var verbose = false
+    
+    enum EngineType: String, ExpressibleByArgument, CaseIterable {
+        case turndown
+        case htmlToMd = "html-to-md"
+        
+        var conversionEngine: ConversionEngine {
+            switch self {
+            case .turndown:
+                return .turndown
+            case .htmlToMd:
+                return .htmlToMd
+            }
+        }
+    }
+    
+    enum HeadingStyleType: String, ExpressibleByArgument, CaseIterable {
+        case setext
+        case atx
+        
+        var demarkStyle: DemarkHeadingStyle {
+            switch self {
+            case .setext:
+                return .setext
+            case .atx:
+                return .atx
+            }
+        }
+    }
+    
+    enum CodeBlockStyleType: String, ExpressibleByArgument, CaseIterable {
+        case indented
+        case fenced
+        
+        var demarkStyle: DemarkCodeBlockStyle {
+            switch self {
+            case .indented:
+                return .indented
+            case .fenced:
+                return .fenced
+            }
+        }
+    }
+    
+    mutating func run() async throws {
+        let htmlContent: String
+        
+        if input == "-" {
+            if verbose {
+                FileHandle.standardError.write(Data("Reading from stdin...\n".utf8))
+            }
+            htmlContent = try readFromStdin()
+        } else {
+            if verbose {
+                FileHandle.standardError.write(Data("Reading from file: \(input)\n".utf8))
+            }
+            let url = URL(fileURLWithPath: input)
+            htmlContent = try String(contentsOf: url, encoding: .utf8)
+        }
+        
+        let options = DemarkOptions(
+            engine: engine.conversionEngine,
+            headingStyle: headingStyle.demarkStyle,
+            bulletListMarker: bulletListMarker,
+            codeBlockStyle: codeBlockStyle.demarkStyle
+        )
+        
+        if verbose {
+            FileHandle.standardError.write(Data("Using engine: \(engine.rawValue)\n".utf8))
+            FileHandle.standardError.write(Data("Converting HTML to Markdown...\n".utf8))
+        }
+        
+        let demark = await Demark()
+        let markdown = try await demark.convertToMarkdown(htmlContent, options: options)
+        
+        if let outputPath = output {
+            if verbose {
+                FileHandle.standardError.write(Data("Writing to file: \(outputPath)\n".utf8))
+            }
+            let outputURL = URL(fileURLWithPath: outputPath)
+            try markdown.write(to: outputURL, atomically: true, encoding: String.Encoding.utf8)
+        } else {
+            print(markdown)
+        }
+        
+        if verbose {
+            FileHandle.standardError.write(Data("Conversion complete!\n".utf8))
+        }
+    }
+    
+    private func readFromStdin() throws -> String {
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Failed to read valid UTF-8 data from stdin")
+        }
+        return content
+    }
+}


### PR DESCRIPTION
## Summary
- Add command-line interface for Demark using Swift Argument Parser
- Enable HTML to Markdown conversion from terminal
- Support both file-based and stdin/stdout workflows

## Changes
- Added `demark` executable target to Package.swift
- Implemented CLI with full argument parsing support
- Added support for both conversion engines (turndown and html-to-md)
- Included all configuration options (heading style, bullet markers, code blocks)
- Updated README with CLI installation and usage instructions
- Added CLAUDE.md for repository guidance

## Usage Examples
```bash
# Convert a file
demark input.html -o output.md

# Use stdin/stdout
echo "<h1>Hello</h1>" | demark -

# Use the fast html-to-md engine
demark input.html --engine html-to-md
```

## Test Plan
- [x] Build the CLI tool successfully
- [x] Test file input/output conversion
- [x] Test stdin/stdout conversion
- [x] Test with both conversion engines
- [x] Verify help output and argument parsing
- [ ] Test on different platforms
- [ ] Add automated tests for CLI